### PR TITLE
Fix duplicate prompt card generation

### DIFF
--- a/DUPLICATE_FIX_SUMMARY.md
+++ b/DUPLICATE_FIX_SUMMARY.md
@@ -1,0 +1,56 @@
+# Duplicate Prompt Card Fix Summary
+
+## Problem Identified
+The Chrome extension was creating duplicate prompt cards when users reopened the extension. This was caused by **multiple initialization** of the PromptHive class.
+
+## Root Cause
+The issue was in the initialization code at the end of `popup.js`:
+
+1. **Lines 1503-1506**: First DOMContentLoaded listener
+2. **Lines 1509-1516**: Conditional logic that added ANOTHER DOMContentLoaded listener OR initialized immediately
+
+When the document was still loading, **both** listeners would fire, creating **two** PromptHive instances, each loading and rendering the same prompts.
+
+## Fixes Implemented
+
+### 1. Fixed Duplicate Initialization (Primary Fix)
+- **File**: `popup.js` (lines 1503-1520)
+- **Solution**: Created a single `initializePromptHive()` function with safeguards
+- **Changes**:
+  - Added check for existing `promptHive` instance
+  - Used `{ once: true }` option for event listener to ensure it only fires once
+  - Simplified logic to avoid duplicate event listeners
+
+### 2. Added Message Listener Safeguard
+- **File**: `popup.js` (setupMessageListener method)
+- **Solution**: Added `messageListenerSetup` flag to prevent duplicate listeners
+- **Changes**:
+  - Added property `this.messageListenerSetup = false` in constructor
+  - Added check in `setupMessageListener()` to prevent duplicate registrations
+
+### 3. Added Event Binding Safeguard
+- **File**: `popup.js` (bindEvents method)
+- **Solution**: Added `eventsBindingSetup` flag to prevent duplicate event binding
+- **Changes**:
+  - Added property `this.eventsBindingSetup = false` in constructor
+  - Added check in `bindEvents()` to prevent duplicate bindings
+
+### 4. Enhanced Logging
+- Added detailed console logging to track initialization attempts
+- Added constructor logging to detect multiple instance creation
+
+## How the Fix Works
+
+1. **Single Entry Point**: Only one initialization path exists now
+2. **Instance Check**: Before creating a new instance, checks if one already exists
+3. **Event Listener Protection**: Uses `{ once: true }` to ensure listeners only fire once
+4. **Method-Level Safeguards**: Each setup method checks if it has already run
+
+## Testing Verification
+- Console logs will show "Creating new PromptHive instance" only once
+- If duplicate initialization is attempted, logs will show "PromptHive already initialized, skipping duplicate initialization"
+- Prompt cards should appear only once when reopening the extension
+
+## Files Modified
+- `popup.js`: Main fixes for initialization and safeguards
+- `DUPLICATE_FIX_SUMMARY.md`: This documentation (can be deleted after verification)


### PR DESCRIPTION
Ensures single initialization of the PromptHive class to prevent duplicate prompt card generation.

Previously, redundant `DOMContentLoaded` listeners in `popup.js` caused multiple `PromptHive` instances to be created, leading to duplicate rendering of prompt cards. This PR refactors the initialization logic to guarantee only one instance is created and adds safeguards against duplicate event listeners.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f94bd2d-09e7-4e45-9955-2236c8e58a5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f94bd2d-09e7-4e45-9955-2236c8e58a5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

